### PR TITLE
Misc fixes

### DIFF
--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/ListDesignerBaseClass.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/ListDesignerBaseClass.lua
@@ -272,6 +272,8 @@ function ListDesignerBaseClass:buildLists(activeListId)
 			}
 		})
 	end
+
+	self:buildModLists(activeListId)
 end
 
 function ListDesignerBaseClass:buildModLists(activeListID)

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/ListDesignerBaseClass.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/ListDesignerBaseClass.lua
@@ -875,6 +875,7 @@ function ListDesignerBaseClass:buildProgressionBrowser()
 									for level, lists in TableUtils:OrderedPairs(indexedProgLevelLists, function(key)
 										return tonumber(key)
 									end) do
+										self.activeList.levels = self.activeList.levels or {}
 										self.activeList.levels[level] = self.activeList.levels[level] or {}
 										local subLevelList = self.activeList.levels[level]
 										subLevelList.manuallySelectedEntries = subLevelList.manuallySelectedEntries or

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/MutationDesigner.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/MutationDesigner.lua
@@ -76,7 +76,7 @@ function MutationDesigner:RenderMutationManager(parent, existingMutation)
 			local selectorColumn = row:AddCell()
 			Styler:CheapTextAlign("Selectors", selectorColumn, "Big").UserData = "keep"
 			Styler:MiddleAlignedColumnLayout(selectorColumn, function(ele)
-				local dryRunButton = ele:AddButton("Dry Run Selectors")
+				local dryRunButton = ele:AddButton("Dry Run")
 				dryRunButton.Disabled = false
 				dryRunButton.UserData = "keep"
 

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/MutationExternalProfileUtility.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/MutationExternalProfileUtility.lua
@@ -282,6 +282,14 @@ function MutationExternalProfileUtility:importProfile(export)
 			if mutationConfig.profiles[profileId] then
 				mutationConfig.profiles[profileId].delete = true
 			end
+
+			if TableUtils:IndexOf(mutationConfig.profiles, function(value)
+					return value.name == profile.name
+				end)
+			then
+				profile.name = string.format("%s (%s)", profile.name, profileId:sub(1, 3))
+			end
+
 			mutationConfig.profiles[profileId] = profile
 		end
 		for folderId, folder in pairs(importedMutations.folders) do

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/MutationProfileManager.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Client/Mutations/MutationProfileManager.lua
@@ -834,13 +834,13 @@ function MutationProfileManager:BuildProfileManager()
 		return (value.modId and ("Z" .. value.modId) or "") .. value.name
 	end) do
 		if not profile.modId then
-			exportProfilesMenu:AddCheckbox(profile.name).UserData = profileId
+			exportProfilesMenu:AddCheckbox(profile.name .. "##" .. profileId).UserData = profileId
 		end
 
 		local isDefault = ConfigurationStructure.config.mutations.settings.defaultProfile == profileId
 
 		---@type ExtuiMenu
-		local profileMenu = manageProfilePopup:AddMenu((isDefault and "(D) " or "") .. profile.name .. (profile.modId and " (M)" or ""))
+		local profileMenu = manageProfilePopup:AddMenu((isDefault and "(D) " or "") .. profile.name .. (profile.modId and " (M)" or "") .. "##" .. profileId)
 
 		if profile.modId then
 			profileMenu:AddSeparatorText("From " .. Ext.Mod.GetMod(profile.modId).Info.Name):SetStyle("Alpha", 0.5)

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/ActionResourcesMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/ActionResourcesMutator.lua
@@ -392,10 +392,10 @@ function ActionResourcesMutator:handleDependencies(export, mutator, removeMissin
 			end
 			TableUtils:ReindexNumericTable(classConfig.requiresClasses)
 
-			for i, resourceConfig in pairs(classConfig.actionResources) do
+			for i, resourceConfig in TableUtils:OrderedPairs(classConfig.actionResources) do
 				if not record(resourceConfig) then
 					classConfig.actionResources[i].delete = true
-					if not classConfig.actionResources() then
+					if (not classConfig.__real and not next(classConfig.actionResources)) or (classConfig.__real and not classConfig.actionResources()) then
 						mutator.values.classDependent[co].delete = true
 						goto continueClass
 					end

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/HealthMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/HealthMutator.lua
@@ -62,7 +62,7 @@ function HealthMutator:renderModifiers(parent, modifiers)
 	cLevelInfoText:SetStyle("SeparatorTextAlign", 0, 0.3)
 	cLevelInfoText:SetStyle("Alpha", 1)
 	cLevelInfoText:Tooltip():AddText(
-		"\t Set the levels at which the modifier changes - for example, setting the modifier to 10% at level 5\nwhen the base modifier is 5% means the modifier will be 5% levels 1-4 and 10% levels 5+")
+		"\t Set the levels at which the modifier increases - for example, setting the modifier to 10% at level 5\nwhen the base modifier is 5% means the modifier will be 5% levels 1-4 and 15% levels 5+")
 
 	parent:AddText("Each character level adds")
 	local baseCLevelMod = parent:AddInputScalar("% to the % Base Health Mutator##characterLevel", characterLevelModifier.value)

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/PassiveList/PassiveListDesigner.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/PassiveList/PassiveListDesigner.lua
@@ -74,9 +74,19 @@ function PassiveListDesigner:customizeDesigner()
 			self.popup:Open()
 
 			for spellListId, spellList in pairs(MutationConfigurationProxy.spellLists) do
-				self.popup:AddSelectable(spellList.name .. (spellList.modId and string.format(" (from %s)", Ext.Mod.GetMod(spellList.modId).Info.Name) or ""), "DontClosePopups").OnClick = function()
-					self.activeList.spellListDependencies = self.activeList.spellListDependencies or {}
-					self.activeList.spellListDependencies[#self.activeList.spellListDependencies + 1] = spellListId
+				---@type ExtuiSelectable
+				local select = self.popup:AddSelectable(spellList.name .. (spellList.modId and string.format(" (from %s)", Ext.Mod.GetMod(spellList.modId).Info.Name) or ""),
+					"DontClosePopups")
+				select.Selected = TableUtils:IndexOf(self.activeList.spellListDependencies, spellListId) ~= nil
+
+				select.OnClick = function()
+					if not select.Selected then
+						self.activeList.spellListDependencies[TableUtils:IndexOf(self.activeList.spellListDependencies, spellListId)] = nil
+						TableUtils:ReindexNumericTable(self.activeList.spellListDependencies)
+					else
+						self.activeList.spellListDependencies = self.activeList.spellListDependencies or {}
+						self.activeList.spellListDependencies[#self.activeList.spellListDependencies + 1] = spellListId
+					end
 
 					buildTable()
 				end

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/PassiveList/PassiveListMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/PassiveList/PassiveListMutator.lua
@@ -56,7 +56,7 @@ function PassiveListMutator:renderMutator(parent, mutator)
 					mutator.values.passiveLists[x] = nil
 					mutator.values.passiveLists[x] = TableUtils:DeeplyCopyTable(mutator.values.passiveLists._real[x + 1])
 				end
-				self:renderMutator(mutatorSection, mutator)
+				self:renderMutator(parent, mutator)
 			end
 
 			local link = mutatorSection:AddTextLink(list.name .. (list.modId and string.format(" (from %s)", Ext.Mod.GetMod(list.modId).Info.Name) or ""))

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/PassiveList/PassiveListMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/PassiveList/PassiveListMutator.lua
@@ -86,10 +86,18 @@ and this list will use the sum of the assigned spell list levels to determine wh
 		popup:Open()
 
 		for passiveListId, passiveList in pairs(MutationConfigurationProxy.passiveLists) do
-			popup:AddSelectable(passiveList.name .. (passiveList.modId and string.format(" (from %s)", Ext.Mod.GetMod(passiveList.modId).Info.Name) or ""), "DontClosePopups").OnClick = function()
-				mutator.values.passiveLists = mutator.values.passiveLists or {}
-				mutator.values.passiveLists[#mutator.values.passiveLists + 1] = passiveListId
-
+			---@type ExtuiSelectable
+			local select = popup:AddSelectable(passiveList.name .. (passiveList.modId and string.format(" (from %s)", Ext.Mod.GetMod(passiveList.modId).Info.Name) or ""),
+				"DontClosePopups")
+			select.Selected = TableUtils:IndexOf(mutator.values.passiveLists, passiveListId) ~= nil
+			select.OnClick = function()
+				if not select.Selected then
+					mutator.values.passiveLists[TableUtils:IndexOf(mutator.values.passiveLists, passiveListId)] = nil
+					TableUtils:ReindexNumericTable(mutator.values.passiveLists)
+				else
+					mutator.values.passiveLists = mutator.values.passiveLists or {}
+					mutator.values.passiveLists[#mutator.values.passiveLists + 1] = passiveListId
+				end
 				self:renderMutator(parent, mutator)
 			end
 		end

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/PassiveList/PassiveListMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/PassiveList/PassiveListMutator.lua
@@ -105,7 +105,6 @@ and this list will use the sum of the assigned spell list levels to determine wh
 		if mutator.values.passives and mutator.values.passives() then
 			for i, passiveId in ipairs(mutator.values.passives) do
 				local delete = Styler:ImageButton(passiveGroup:AddImageButton("delete" .. passiveId, "ico_red_x", { 16, 16 }))
-				delete.SameLine = (i - 1) % 3 ~= 0
 				delete.OnClick = function()
 					for x = i, TableUtils:CountElements(mutator.values.passives) do
 						mutator.values.passives[x] = nil

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/ProgressionsMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/ProgressionsMutator.lua
@@ -8,6 +8,10 @@ function ProgressionsMutator:canBeAdditive()
 	return true
 end
 
+function ProgressionsMutator:handleDependencies()
+	-- NOOP
+end
+
 ---@class ProgressionConditionalGroup
 ---@field progressionTableIds {[Guid] : number}?
 ---@field spellListDependencies Guid[]?

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/SpellList/SpellListMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/SpellList/SpellListMutator.lua
@@ -43,7 +43,6 @@ function SpellListMutator:renderMutator(parent, mutator)
 
 	local displayTable = parent:AddTable("SpellList", 2)
 	displayTable.Resizable = true
-	displayTable.NoSavedSettings = true
 	displayTable.Borders = true
 
 	local popup = parent:AddPopup("spellListMutatorPopup")
@@ -54,6 +53,7 @@ function SpellListMutator:renderMutator(parent, mutator)
 		local groupCell = parentRow:AddCell()
 
 		local header = groupCell:AddCollapsingHeader("Group " .. sMG)
+		header.IDContext = "Group" .. sMG
 
 		local delete = Styler:ImageButton(header:AddImageButton("delete" .. mutator.targetProperty, "ico_red_x", { 16, 16 }))
 		delete:Tooltip():AddText("\t Delete Group")
@@ -66,6 +66,7 @@ function SpellListMutator:renderMutator(parent, mutator)
 		end
 		local poolGroup = header:AddGroup("Group")
 		local function renderPools()
+			Helpers:KillChildren(poolGroup)
 			local leveledTable = poolGroup:AddTable("leveledTable", 1)
 			leveledTable.NoSavedSettings = true
 			leveledTable.Borders = true
@@ -82,7 +83,7 @@ function SpellListMutator:renderMutator(parent, mutator)
 							spellMutatorGroup.leveledSpellPool[x] = TableUtils:DeeplyCopyTable(spellMutatorGroup.leveledSpellPool._real[x + 1])
 						end
 
-						self:renderMutator(parent, mutator)
+						renderPools()
 					end
 
 					cell:AddText("Level is equal to or greater than: ").SameLine = true
@@ -149,7 +150,6 @@ function SpellListMutator:renderMutator(parent, mutator)
 									select.Selected = true
 									table.insert(leveledSpellPool.spellLists, id)
 								end
-								Helpers:KillChildren(poolGroup)
 								renderPools()
 							end
 						end
@@ -191,7 +191,6 @@ function SpellListMutator:renderMutator(parent, mutator)
 												select.Selected = true
 												table.insert(leveledSpellPool.spellLists, guid)
 											end
-											Helpers:KillChildren(poolGroup)
 											renderPools()
 										end
 									end
@@ -211,8 +210,13 @@ function SpellListMutator:renderMutator(parent, mutator)
 		addLeveledPoolButton.OnClick = function()
 			Helpers:KillChildren(poolGroup)
 			spellMutatorGroup.leveledSpellPool = spellMutatorGroup.leveledSpellPool or {}
+			local lastAnchor = 1
+			for _, pool in pairs(spellMutatorGroup.leveledSpellPool) do
+				lastAnchor = pool.anchorLevel > lastAnchor and pool.anchorLevel or lastAnchor
+			end
+
 			table.insert(spellMutatorGroup.leveledSpellPool, {
-				anchorLevel = 1,
+				anchorLevel = lastAnchor + 1,
 				spellLists = {}
 			} --[[@as LeveledSpellPool]])
 
@@ -507,14 +511,14 @@ function SpellListMutator:renderCriteriaSettings(parent, spellMutatorGroup)
 
 		row:AddCell():AddText(ability)
 
-		local combo           = row:AddCell():AddCombo("")
+		local combo = row:AddCell():AddCombo("")
 		combo.WidthFitPreview = true
-		combo.Options         = { ">=", "<=" }
-		combo.SelectedIndex   = existingCriteria and existingCriteria.comparator == "lte" and 1 or 0
+		combo.Options = { ">=", "<=" }
+		combo.SelectedIndex = existingCriteria and existingCriteria.comparator == "lte" and 1 or 0
 
-		local input           = row:AddCell():AddInputInt("", existingCriteria and existingCriteria.value)
+		local input = row:AddCell():AddInputInt("", existingCriteria and existingCriteria.value)
 
-		combo.OnChange        = function()
+		combo.OnChange = function()
 			if input.Value[1] > 1 then
 				if not existingCriteria then
 					spellMutatorGroup.criteria = spellMutatorGroup.criteria or {}
@@ -526,7 +530,7 @@ function SpellListMutator:renderCriteriaSettings(parent, spellMutatorGroup)
 			end
 		end
 
-		input.OnChange        = function()
+		input.OnChange = function()
 			if not existingCriteria then
 				spellMutatorGroup.criteria = spellMutatorGroup.criteria or {}
 				spellMutatorGroup.criteria.abilityCondition = spellMutatorGroup.criteria.abilityCondition or {}

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/SpellList/SpellListMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/SpellList/SpellListMutator.lua
@@ -210,7 +210,7 @@ function SpellListMutator:renderMutator(parent, mutator)
 		addLeveledPoolButton.OnClick = function()
 			Helpers:KillChildren(poolGroup)
 			spellMutatorGroup.leveledSpellPool = spellMutatorGroup.leveledSpellPool or {}
-			local lastAnchor = 1
+			local lastAnchor = 0
 			for _, pool in pairs(spellMutatorGroup.leveledSpellPool) do
 				lastAnchor = pool.anchorLevel > lastAnchor and pool.anchorLevel or lastAnchor
 			end

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/StatusList/StatusListDesigner.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/StatusList/StatusListDesigner.lua
@@ -58,9 +58,19 @@ function StatusListDesigner:customizeDesigner()
 			self.popup:Open()
 
 			for spellListId, spellList in pairs(MutationConfigurationProxy.spellLists) do
-				self.popup:AddSelectable(spellList.name .. (spellList.modId and string.format(" (from %s)", Ext.Mod.GetMod(spellList.modId).Info.Name) or ""), "DontClosePopups").OnClick = function()
-					self.activeList.spellListDependencies = self.activeList.spellListDependencies or {}
-					self.activeList.spellListDependencies[#self.activeList.spellListDependencies + 1] = spellListId
+				---@type ExtuiSelectable
+				local select = self.popup:AddSelectable(spellList.name .. (spellList.modId and string.format(" (from %s)", Ext.Mod.GetMod(spellList.modId).Info.Name) or ""),
+					"DontClosePopups")
+				select.Selected = TableUtils:IndexOf(self.activeList.spellListDependencies, spellListId) ~= nil
+
+				select.OnClick = function()
+					if not select.Selected then
+						self.activeList.spellListDependencies[TableUtils:IndexOf(self.activeList.spellListDependencies, spellListId)] = nil
+						TableUtils:ReindexNumericTable(self.activeList.spellListDependencies)
+					else
+						self.activeList.spellListDependencies = self.activeList.spellListDependencies or {}
+						self.activeList.spellListDependencies[#self.activeList.spellListDependencies + 1] = spellListId
+					end
 
 					buildTable()
 				end

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/StatusList/StatusListMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/StatusList/StatusListMutator.lua
@@ -112,7 +112,6 @@ and this list will use the sum of the assigned spell list levels to determine wh
 		if mutator.values.statuses and mutator.values.statuses() then
 			for i, statusId in ipairs(mutator.values.statuses) do
 				local delete = Styler:ImageButton(statusGroup:AddImageButton("delete" .. statusId, "ico_red_x", { 16, 16 }))
-				delete.SameLine = (i - 1) % 3 ~= 0
 				delete.OnClick = function()
 					for x = i, TableUtils:CountElements(mutator.values.statuses) do
 						mutator.values.statuses[x] = nil

--- a/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/StatusList/StatusListMutator.lua
+++ b/Absolutes_Laboratory/Mods/Absolutes_Laboratory/ScriptExtender/Lua/Shared/Mutations/Mutators/StatusList/StatusListMutator.lua
@@ -31,7 +31,7 @@ function StatusListMutator:renderMutator(parent, mutator)
 	statusListDesignerButton.OnClick = function()
 		StatusListDesigner:launch()
 	end
-local sectionTable = parent:AddTable("Sections", 2)
+	local sectionTable = parent:AddTable("Sections", 2)
 	sectionTable.BordersOuter = true
 	local sectionsRow = sectionTable:AddRow()
 	local mutatorSection = sectionsRow:AddCell()
@@ -55,7 +55,7 @@ local sectionTable = parent:AddTable("Sections", 2)
 					mutator.values.statusLists[x] = nil
 					mutator.values.statusLists[x] = TableUtils:DeeplyCopyTable(mutator.values.statusLists._real[x + 1])
 				end
-				self:renderMutator(mutatorSection, mutator)
+				self:renderMutator(parent, mutator)
 			end
 
 			local link = mutatorSection:AddTextLink(list.name .. (list.modId and string.format(" (from %s)", Ext.Mod.GetMod(list.modId).Info.Name) or ""))
@@ -85,10 +85,18 @@ and this list will use the sum of the assigned spell list levels to determine wh
 		popup:Open()
 
 		for statusListId, statusList in pairs(MutationConfigurationProxy.statusLists) do
-			popup:AddSelectable(statusList.name .. (statusList.modId and string.format(" (from %s)", Ext.Mod.GetMod(statusList.modId).Info.Name) or ""), "DontClosePopups").OnClick = function()
-				mutator.values.statusLists = mutator.values.statusLists or {}
-				mutator.values.statusLists[#mutator.values.statusLists + 1] = statusListId
-
+			---@type ExtuiSelectable
+			local select = popup:AddSelectable(statusList.name .. (statusList.modId and string.format(" (from %s)", Ext.Mod.GetMod(statusList.modId).Info.Name) or ""),
+				"DontClosePopups")
+			select.Selected = TableUtils:IndexOf(mutator.values.statusLists, statusListId) ~= nil
+			select.OnClick = function()
+				if not select.Selected then
+					mutator.values.statusLists[TableUtils:IndexOf(mutator.values.statusLists, statusListId)] = nil
+					TableUtils:ReindexNumericTable(mutator.values.statusLists)
+				else
+					mutator.values.statusLists = mutator.values.statusLists or {}
+					mutator.values.statusLists[#mutator.values.statusLists + 1] = statusListId
+				end
 				self:renderMutator(parent, mutator)
 			end
 		end

--- a/Export_Mod_Example/Mods/Export_Mod_Example/meta.lsx
+++ b/Export_Mod_Example/Mods/Export_Mod_Example/meta.lsx
@@ -6,6 +6,27 @@
       <children>
         <node id="Dependencies">
           <children>
+            <node id="ModuleShortDesc">
+              <attribute id="Folder" type="LSWString" value="Attunement" />
+              <attribute id="MD5" type="LSString" value="" />
+              <attribute id="Name" type="FixedString" value="Attunement" />
+              <attribute id="UUID" type="FixedString" value="7a526492-f5f4-44a0-ab25-ddcc4c6c1e7e" />
+              <attribute id="Version64" type="int64" value="36451020221448192" />
+            </node>
+            <node id="ModuleShortDesc">
+              <attribute id="Folder" type="LSWString" value="Valkrana's Skeleton Crew Feat" />
+              <attribute id="MD5" type="LSString" value="" />
+              <attribute id="Name" type="FixedString" value="Valkrana's Skeleton Crew Feat" />
+              <attribute id="UUID" type="FixedString" value="d76ff1e5-e09e-4565-a9d2-a035037f6134" />
+              <attribute id="Version64" type="int64" value="38702811445198848" />
+            </node>
+            <node id="ModuleShortDesc">
+              <attribute id="Folder" type="LSWString" value="Absolutes_Laboratory" />
+              <attribute id="MD5" type="LSString" value="" />
+              <attribute id="Name" type="FixedString" value="Absolute's Laboratory" />
+              <attribute id="UUID" type="FixedString" value="a17a3a3d-5c16-404a-910a-68ae9e47f247" />
+              <attribute id="Version64" type="int64" value="36028797018963968" />
+            </node>
           </children>
         </node>
         <node id="ModuleInfo">


### PR DESCRIPTION
- Fixes copy all in lists when a level isn't created yet
- Cleans up collapsible behavior in Spell List mutators a bit
- Fix tooltip in Health Mutator
- Fix Mod Lists not showing up
- Put loose status/passive hyperlinks on their own lines in their respective mutators
- Fix rendering issue in status/passive mutators
- QOL around linking Spell Lists in status/passive list designers
- Fix export errors for Action Resources and Progression mutators
- Append profile id to profile names when the same profile name already exists locally
- Add Dependencies to the Export Example's meta.lsx